### PR TITLE
Fix Docker backend ASGI module import error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,6 +32,6 @@ EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:5000/api/health || exit 1
 
-# Run the application
-CMD ["python", "main.py"]
+# Run the application with Gunicorn WSGI server
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "--timeout", "120", "main:app"]
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 """
 Main entry point for the SSL Certificate Toolkit backend.
-This module provides compatibility for both WSGI and ASGI servers.
+This module provides the Flask WSGI application for production servers (Gunicorn).
 """
 
 from app import create_app
 import os
 
 # Create the Flask application instance
+# This is used by Gunicorn with: gunicorn main:app
 app = create_app()
 
-# For ASGI compatibility (uvicorn, etc.)
-# This allows the app to be imported as main:app
-app_asgi = app
-
-# For WSGI compatibility (gunicorn, etc.)
 if __name__ == "__main__":
-    # Development server
+    # Development server (for local testing only)
+    # In production, use Gunicorn instead
     port = int(os.environ.get("PORT", 5000))
     app.run(host="0.0.0.0", port=port, debug=True)


### PR DESCRIPTION
…erver

- Update Dockerfile CMD to use Gunicorn with proper WSGI configuration
- Configure Gunicorn with 4 workers and 120s timeout for production
- Remove misleading ASGI compatibility comments from main.py
- Flask is a WSGI framework and should be run with a WSGI server like Gunicorn

This fixes the "Could not import module 'main'" error when starting the Docker container.