### PR TITLE
fix(backend): resolve f-string syntax error in ssl_checker.py

### DIFF
--- a/backend/app/services/ssl_checker.py
+++ b/backend/app/services/ssl_checker.py
@@ -83,7 +83,8 @@ def check_ssl_certificate(hostname, port=443, timeout=10):
 def check_hostname_validity(hostname, cert_info):
     """Check if certificate is valid for the given hostname"""
     common_name = cert_info.get('subject', {}).get('common_name')
-    if common_name and (common_name == hostname or common_name == f'*.{hostname.split('.', 1)[-1]}'):
+    wildcard_domain = '*.' + hostname.split('.', 1)[-1] if '.' in hostname else ''
+    if common_name and (common_name == hostname or common_name == wildcard_domain):
         return True
 
     san_list = cert_info.get('subject_alternative_names', [])


### PR DESCRIPTION
Fixed Python 3.11 f-string syntax error on line 86 where unmatched parentheses in f'*.{hostname.split('.', 1)[-1]}' caused SyntaxError.

Changed to extract the expression outside the f-string for compatibility.