### PR TITLE
fix(nginx): disable HTTPS server block for development

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -41,46 +41,53 @@ server {
 }
 
 # HTTPS server (for production)
-server {
-    listen 443 ssl http2;
-    server_name localhost;
-
-    # SSL configuration (use your own certificates)
-    ssl_certificate /etc/nginx/ssl/cert.pem;
-    ssl_certificate_key /etc/nginx/ssl/key.pem;
-    ssl_protocols TLSv1.2 TLSv1.3;
-    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA;
-    ssl_prefer_server_ciphers off;
-    ssl_dhparam /etc/nginx/ssl/dhparam.pem;
-
-    # Security headers for HTTPS
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "no-referrer-when-downgrade" always;
-
-    # API routes
-    location /api {
-        proxy_pass http://backend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        
-        # Increase timeout for SSL operations
-        proxy_connect_timeout 120s;
-        proxy_send_timeout 120s;
-        proxy_read_timeout 120s;
-    }
-
-    # Frontend routes
-    location / {
-        proxy_pass http://frontend;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
+# Commented out for development - uncomment and add SSL certificates for production
+# To enable HTTPS, generate certificates and place them in ./certs/ directory:
+#   - cert.pem (SSL certificate)
+#   - key.pem (SSL private key)
+#   - dhparam.pem (Diffie-Hellman parameters)
+#
+# server {
+#     listen 443 ssl;
+#     http2 on;
+#     server_name localhost;
+#
+#     # SSL configuration (use your own certificates)
+#     ssl_certificate /etc/nginx/ssl/cert.pem;
+#     ssl_certificate_key /etc/nginx/ssl/key.pem;
+#     ssl_protocols TLSv1.2 TLSv1.3;
+#     ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA;
+#     ssl_prefer_server_ciphers off;
+#     ssl_dhparam /etc/nginx/ssl/dhparam.pem;
+#
+#     # Security headers for HTTPS
+#     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+#     add_header X-Frame-Options "SAMEORIGIN" always;
+#     add_header X-XSS-Protection "1; mode=block" always;
+#     add_header X-Content-Type-Options "nosniff" always;
+#     add_header Referrer-Policy "no-referrer-when-downgrade" always;
+#
+#     # API routes
+#     location /api {
+#         proxy_pass http://backend;
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#
+#         # Increase timeout for SSL operations
+#         proxy_connect_timeout 120s;
+#         proxy_send_timeout 120s;
+#         proxy_read_timeout 120s;
+#     }
+#
+#     # Frontend routes
+#     location / {
+#         proxy_pass http://frontend;
+#         proxy_set_header Host $host;
+#         proxy_set_header X-Real-IP $remote_addr;
+#         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#         proxy_set_header X-Forwarded-Proto $scheme;
+#     }
+# }
 


### PR DESCRIPTION
Commented out the HTTPS server block to allow nginx to start without SSL certificates in development environments.

Also fixed the deprecated "listen 443 ssl http2" syntax to the new format: "listen 443 ssl" + "http2 on"

To enable HTTPS in production:
1. Generate SSL certificates
2. Place them in ./certs/ directory
3. Uncomment the HTTPS server block