### PR TITLE
docs: add comprehensive troubleshooting guide and rebuild script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ A comprehensive web-based SSL/TLS certificate management toolkit built with Flas
    - The backend API will be available at `http://localhost/api`
 
 **Note**: If you see a default web server page instead of the application:
-- Run `docker-compose build frontend` to rebuild the frontend container
-- Then restart: `docker-compose up -d`
+- Quick fix: Run `./rebuild-frontend.sh` (provided in the repository)
+- Or manually: `docker compose build frontend --no-cache && docker compose up -d`
+- See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for detailed solutions
 
 ### Development Mode
 
@@ -140,87 +141,27 @@ For HTTPS support in production:
 
 ## Troubleshooting
 
-### Backend won't start - "Could not import module 'main'"
+Having issues? See the comprehensive [TROUBLESHOOTING.md](TROUBLESHOOTING.md) guide for detailed solutions.
 
-**Issue**: The backend fails to start with an ASGI import error or module import error.
+### Quick Fixes
 
-**Solution**: This was fixed in commit `6bcdd31`. The backend now uses Gunicorn WSGI server instead of Flask development server. Pull the latest changes and rebuild:
-
+**Frontend shows default page?**
 ```bash
-git pull origin main
-docker-compose down
-docker-compose build backend
-docker-compose up -d
+./rebuild-frontend.sh
 ```
 
-### Seeing Apache/Nginx default page
-
-**Issue**: When accessing `http://localhost`, you see a default web server page instead of the SSL Toolkit application.
-
-**Solution**: The frontend container needs to be rebuilt to include the React application:
-
+**Backend won't start?**
 ```bash
-docker-compose down
-docker-compose build frontend
-docker-compose up -d
+docker compose build backend --no-cache
+docker compose up -d
 ```
 
-### Nginx fails with SSL certificate error
-
-**Issue**: Nginx container fails to start with error about missing `/etc/nginx/ssl/cert.pem`.
-
-**Solution**: This was fixed in commit `f7cf54d`. HTTPS is now disabled by default for development. Pull the latest changes:
-
+**View logs:**
 ```bash
-git pull origin main
-docker-compose restart nginx
+docker compose logs -f
 ```
 
-To enable HTTPS, see the [SSL/HTTPS Configuration](#sslhttps-configuration) section above.
-
-### Python syntax error in ssl_checker.py
-
-**Issue**: Backend crashes with `SyntaxError: f-string: unmatched '('` in `ssl_checker.py:86`.
-
-**Solution**: This was fixed in commit `20ecb42`. Pull the latest changes and rebuild:
-
-```bash
-git pull origin main
-docker-compose build backend
-docker-compose up -d
-```
-
-### Port already in use
-
-**Issue**: Docker Compose fails with "port is already allocated".
-
-**Solution**: Another service is using port 80 or 5000. Either:
-
-1. Stop the conflicting service
-2. Or modify `docker-compose.yml` to use different ports:
-   ```yaml
-   nginx:
-     ports:
-       - "8080:80"  # Use port 8080 instead of 80
-   ```
-
-### Containers keep restarting
-
-**Issue**: Containers continuously restart in a crash loop.
-
-**Solution**: Check container logs for specific errors:
-
-```bash
-# Check all container logs
-docker-compose logs
-
-# Check specific container
-docker-compose logs backend
-docker-compose logs frontend
-docker-compose logs nginx
-```
-
-Then follow the specific troubleshooting steps for the error you see.
+For detailed troubleshooting of all common issues, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ## API Documentation
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,324 @@
+# Troubleshooting Guide
+
+## Frontend Shows Default/Apache Page
+
+### Problem
+When accessing `http://localhost`, you see a default web server page (Apache, nginx, or "Welcome to nginx!") instead of the SSL Toolkit application.
+
+### Why This Happens
+The frontend container serves a static build of the React application. If you see a default page, it means:
+
+1. **The frontend container hasn't been built yet** - The React app needs to be compiled into static files
+2. **The build failed during initial setup** - npm build errors weren't visible
+3. **The container is using cached layers** - An incomplete build is cached
+
+### Quick Fix
+
+Run the provided script:
+
+```bash
+./rebuild-frontend.sh
+```
+
+Or manually:
+
+```bash
+# Stop all containers
+docker compose down
+
+# Rebuild frontend without cache
+docker compose build frontend --no-cache
+
+# Start everything
+docker compose up -d
+```
+
+### Verify the Build
+
+After rebuilding, verify the containers are running:
+
+```bash
+docker compose ps
+```
+
+You should see all three containers (backend, frontend, nginx) with status "Up".
+
+Check frontend logs for any errors:
+
+```bash
+docker compose logs frontend
+```
+
+You should see:
+- npm install output
+- npm run build output
+- nginx starting
+
+### Common Build Issues
+
+#### 1. Node/npm version issues
+
+**Error**: `npm ERR! code EBADENGINE`
+
+**Solution**: The Dockerfile uses `node:18-alpine`. If you need a different version, edit `frontend/Dockerfile`:
+
+```dockerfile
+FROM node:20-alpine as build  # Change to node:20-alpine
+```
+
+#### 2. Out of memory during build
+
+**Error**: `FATAL ERROR: Reached heap limit`
+
+**Solution**: Increase Docker memory limit in Docker Desktop settings, or build with more memory:
+
+```bash
+docker compose build frontend --memory=4g
+```
+
+#### 3. Missing dependencies
+
+**Error**: `Module not found` errors
+
+**Solution**: Delete node_modules and reinstall:
+
+```bash
+cd frontend
+rm -rf node_modules package-lock.json
+docker compose build frontend --no-cache
+```
+
+## Backend Import Errors
+
+### Problem: "Could not import module 'main'"
+
+**Fixed in**: Commit `6bcdd31`
+
+This was caused by trying to run Flask with an ASGI server. The backend now correctly uses Gunicorn WSGI server.
+
+**Solution**: Pull latest changes and rebuild:
+
+```bash
+git pull origin main
+docker compose build backend
+docker compose up -d
+```
+
+## Nginx SSL Certificate Error
+
+### Problem: Cannot load certificate "/etc/nginx/ssl/cert.pem"
+
+**Fixed in**: Commit `f7cf54d`
+
+HTTPS is now disabled by default for development.
+
+**Solution**: Already fixed in main branch. Pull and restart:
+
+```bash
+git pull origin main
+docker compose restart nginx
+```
+
+To enable HTTPS, see [README.md - SSL/HTTPS Configuration](README.md#sslhttps-configuration).
+
+## Python Syntax Error in ssl_checker.py
+
+### Problem: `SyntaxError: f-string: unmatched '('`
+
+**Fixed in**: Commit `20ecb42`
+
+This was a Python 3.11 f-string syntax issue.
+
+**Solution**: Already fixed in main branch:
+
+```bash
+git pull origin main
+docker compose build backend
+docker compose up -d
+```
+
+## Port Conflicts
+
+### Problem: "port is already allocated"
+
+Another service is using port 80, 443, or 5000.
+
+**Solution 1**: Stop the conflicting service
+
+Find what's using the port:
+
+```bash
+# On Linux/Mac
+sudo lsof -i :80
+sudo lsof -i :5000
+
+# On Windows
+netstat -ano | findstr :80
+netstat -ano | findstr :5000
+```
+
+**Solution 2**: Use different ports
+
+Edit `docker-compose.yml`:
+
+```yaml
+nginx:
+  ports:
+    - "8080:80"  # Use 8080 instead of 80
+```
+
+Then access at `http://localhost:8080`
+
+## Container Restart Loops
+
+### Problem: Containers keep restarting
+
+Check logs to identify the specific error:
+
+```bash
+# View all logs
+docker compose logs
+
+# View specific container
+docker compose logs backend
+docker compose logs frontend
+docker compose logs nginx
+
+# Follow logs in real-time
+docker compose logs -f backend
+```
+
+Then follow the specific troubleshooting steps for the error you see.
+
+## Health Check Failures
+
+### Problem: Container shows as "unhealthy"
+
+Check health status:
+
+```bash
+docker compose ps
+```
+
+Inspect health check logs:
+
+```bash
+docker inspect ssl-toolkit-backend | grep -A 10 Health
+docker inspect ssl-toolkit-frontend | grep -A 10 Health
+```
+
+### Backend health check failing
+
+The backend health check tests `http://localhost:5000/api/health`.
+
+Verify it manually:
+
+```bash
+docker compose exec backend curl http://localhost:5000/api/health
+```
+
+If it fails, check backend logs:
+
+```bash
+docker compose logs backend
+```
+
+### Frontend health check failing
+
+The frontend health check tests `http://localhost:80`.
+
+Verify manually:
+
+```bash
+docker compose exec frontend curl http://localhost:80
+```
+
+## Network Issues
+
+### Problem: Containers can't communicate
+
+Verify all containers are on the same network:
+
+```bash
+docker network ls
+docker network inspect ssl-toolkit_ssl-toolkit-network
+```
+
+All three containers should be listed under "Containers".
+
+### Problem: Cannot access from host
+
+Check Docker networking mode:
+
+```bash
+docker compose ps
+```
+
+Verify port mappings show `0.0.0.0:80->80/tcp`.
+
+## Complete Reset
+
+If all else fails, completely reset:
+
+```bash
+# Stop and remove everything
+docker compose down -v
+
+# Remove all images
+docker compose down --rmi all
+
+# Clean Docker build cache
+docker builder prune -a
+
+# Rebuild from scratch
+docker compose build --no-cache
+
+# Start fresh
+docker compose up -d
+```
+
+## Getting Help
+
+If you're still having issues:
+
+1. **Check logs**: `docker compose logs`
+2. **Check container status**: `docker compose ps`
+3. **Verify Docker**: `docker --version` and `docker compose version`
+4. **Check this guide**: Make sure you've tried the relevant solutions
+5. **Create an issue**: Include logs and error messages
+
+## Useful Commands
+
+```bash
+# View all containers
+docker compose ps
+
+# View logs for all services
+docker compose logs
+
+# View logs for specific service
+docker compose logs backend
+docker compose logs frontend
+docker compose logs nginx
+
+# Follow logs in real-time
+docker compose logs -f
+
+# Restart specific service
+docker compose restart backend
+
+# Rebuild and restart specific service
+docker compose up -d --build frontend
+
+# Stop all services
+docker compose down
+
+# Stop and remove volumes
+docker compose down -v
+
+# Check Docker disk usage
+docker system df
+
+# Clean up unused resources
+docker system prune
+```

--- a/rebuild-frontend.sh
+++ b/rebuild-frontend.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to rebuild the frontend container
+# This is needed if you see the Apache/nginx default page instead of the SSL Toolkit app
+
+echo "🔨 Rebuilding frontend container..."
+echo ""
+
+# Stop the containers
+echo "1. Stopping containers..."
+docker compose down
+
+# Rebuild the frontend
+echo ""
+echo "2. Building frontend (this may take several minutes)..."
+docker compose build frontend --no-cache
+
+# Start all containers
+echo ""
+echo "3. Starting all containers..."
+docker compose up -d
+
+# Wait for containers to start
+echo ""
+echo "⏳ Waiting for containers to start..."
+sleep 5
+
+# Show container status
+echo ""
+echo "📊 Container status:"
+docker compose ps
+
+echo ""
+echo "✅ Done! Access the application at http://localhost"
+echo ""
+echo "To view logs:"
+echo "  docker compose logs -f frontend"
+echo "  docker compose logs -f backend"
+echo "  docker compose logs -f nginx"


### PR DESCRIPTION
Added:
- TROUBLESHOOTING.md: Comprehensive guide covering all common issues
  * Frontend default page issue (most common)
  * Backend import errors
  * Nginx SSL certificate errors
  * Python syntax errors
  * Port conflicts
  * Container restart loops
  * Health check failures
  * Network issues
  * Complete reset procedure
  * Useful Docker commands

- rebuild-frontend.sh: Automated script to rebuild frontend container
  * Stops containers
  * Rebuilds frontend without cache
  * Restarts all containers
  * Shows status and helpful commands

- Updated README.md:
  * Added quick fix with rebuild script
  * Simplified troubleshooting section
  * Added reference to detailed TROUBLESHOOTING.md

This addresses the common issue where users see Apache/nginx default page instead of the SSL Toolkit application.